### PR TITLE
fix: executable permission on macos target

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 use rand::Rng;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 use std::os::unix::fs::PermissionsExt;
 use std::process::Command;
 use thirtyfour::{DesiredCapabilities, WebDriver};
@@ -84,7 +84,7 @@ pub async fn chrome() -> Result<WebDriver, Box<dyn std::error::Error>> {
             println!("Detected patched chromedriver executable!");
         }
     }
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
     {
         let mut perms = std::fs::metadata(chromedriver_executable)
             .unwrap()


### PR DESCRIPTION
**Changelog:**
* Fixes permissions of the patched chromedriver on MacOS, without this patch, the user must execute `chmod +x <path>`.

**Notes:**
By the way, I plan doing other contributions to the project, notably, make `DesiredCapabilities` struct public before executing Chrome, this allows changing Chrome binary, according to issue #1.