### PR TITLE
Refractor and Bug Fixes.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ pub async fn chrome() -> Result<WebDriver, Box<dyn std::error::Error>> {
             let mut cdc_pos_list = Vec::new();
             let mut is_cdc_present = false;
             let mut patch_ct = 0;
-            for i in 0..f.len() {
+            for i in 0..f.len() - 3 {
                 if "cdc_"
                     == format!(
                         "{}{}{}{}",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,7 +126,7 @@ async fn fetch_chromedriver(client: &reqwest::Client) -> Result<(), Box<dyn std:
 
     let installed_version = get_chrome_version(os).await?;
     let chromedriver_url: String;
-    if installed_version >= "114".to_string() {
+    if installed_version.as_str() >= "114" {
         // Fetch the correct version
         let url = "https://googlechromelabs.github.io/chrome-for-testing/latest-versions-per-milestone.json";
         let resp = client.get(url).send().await?;
@@ -185,7 +185,7 @@ async fn fetch_chromedriver(client: &reqwest::Client) -> Result<(), Box<dyn std:
     for i in 0..archive.len() {
         let mut file = archive.by_index(i)?;
         let outpath = file.mangled_name();
-        if (&*file.name()).ends_with('/') {
+        if file.name().ends_with('/') {
             std::fs::create_dir_all(&outpath)?;
         } else {
             let outpath_relative = outpath.file_name().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,16 @@
 use rand::Rng;
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 use std::os::unix::fs::PermissionsExt;
-use std::process::Command;
+use std::{fs::File, io::Read, process::Command};
 use thirtyfour::{DesiredCapabilities, WebDriver};
 
 /// Fetches a new ChromeDriver executable and patches it to prevent detection.
 /// Returns a WebDriver instance.
 pub async fn chrome() -> Result<WebDriver, Box<dyn std::error::Error>> {
     let os = std::env::consts::OS;
-    if std::path::Path::new("chromedriver").exists() {
+    if std::path::Path::new("chromedriver").exists()
+        || std::path::Path::new("chromedriver.exe").exists()
+    {
         println!("ChromeDriver already exists!");
     } else {
         println!("ChromeDriver does not exist! Fetching...");
@@ -209,4 +211,21 @@ async fn get_chrome_version(os: &str) -> Result<String, Box<dyn std::error::Erro
     let version = output.replace("Google Chrome ", "")[0..3].to_string();
     println!("Currently installed Chrome version: {}", version);
     Ok(version)
+}
+fn patch_file() {
+    let mut f = File::open("chromedriver.exe").expect("Unable to open chromedriver");
+    let mut buffer = vec![];
+    f.read_to_end(&mut buffer)
+        .expect("Unable to copy chromedriver contents in the new file");
+
+
+    
+}
+mod test {
+    use crate::patch_file;
+
+    #[test]
+    fn test_patch() {
+        patch_file();
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 use rand::Rng;
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 use std::os::unix::fs::PermissionsExt;
-use std::{fs::File, io::Read, process::Command};
+use std::process::Command;
 use thirtyfour::{DesiredCapabilities, WebDriver};
 
 /// Fetches a new ChromeDriver executable and patches it to prevent detection.
@@ -65,7 +65,7 @@ pub async fn chrome() -> Result<WebDriver, Box<dyn std::error::Error>> {
                     .chars()
                     .collect::<Vec<char>>()[rand::thread_rng().gen_range(0..48)]
             };
-            
+
             for i in cdc_pos_list {
                 for x in i + 4..i + 22 {
                     new_chromedriver_bytes[x] = get_random_char() as u8;
@@ -213,17 +213,3 @@ async fn get_chrome_version(os: &str) -> Result<String, Box<dyn std::error::Erro
     println!("Currently installed Chrome version: {}", version);
     Ok(version)
 }
-fn patch_file() {
-    let mut f = File::open("chromedriver.exe").expect("Unable to open chromedriver");
-    let mut buffer = String::new();
-    f.read_to_string(&mut buffer)
-        .expect("Unable to copy chromedriver contents in the new file");
-}
-// mod test {
-//     use crate::patch_file;
-
-//     #[test]
-//     fn test_patch() {
-//         patch_file();
-//     }
-// }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ pub async fn chrome() -> Result<WebDriver, Box<dyn std::error::Error>> {
             let mut cdc_pos_list = Vec::new();
             let mut is_cdc_present = false;
             let mut patch_ct = 0;
-            for i in 0..f.len() - 3 {
+            for i in 0..f.len() {
                 if "cdc_"
                     == format!(
                         "{}{}{}{}",
@@ -48,7 +48,7 @@ pub async fn chrome() -> Result<WebDriver, Box<dyn std::error::Error>> {
                     )
                     .as_str()
                 {
-                    for x in i..i + 22 {
+                    for x in i + 4..i + 22 {
                         total_cdc.push_str(&(f[x] as char).to_string());
                     }
                     is_cdc_present = true;
@@ -65,8 +65,9 @@ pub async fn chrome() -> Result<WebDriver, Box<dyn std::error::Error>> {
                     .chars()
                     .collect::<Vec<char>>()[rand::thread_rng().gen_range(0..48)]
             };
+            
             for i in cdc_pos_list {
-                for x in i..i + 22 {
+                for x in i + 4..i + 22 {
                     new_chromedriver_bytes[x] = get_random_char() as u8;
                 }
                 patch_ct += 1;
@@ -214,18 +215,15 @@ async fn get_chrome_version(os: &str) -> Result<String, Box<dyn std::error::Erro
 }
 fn patch_file() {
     let mut f = File::open("chromedriver.exe").expect("Unable to open chromedriver");
-    let mut buffer = vec![];
-    f.read_to_end(&mut buffer)
+    let mut buffer = String::new();
+    f.read_to_string(&mut buffer)
         .expect("Unable to copy chromedriver contents in the new file");
-
-
-    
 }
-mod test {
-    use crate::patch_file;
+// mod test {
+//     use crate::patch_file;
 
-    #[test]
-    fn test_patch() {
-        patch_file();
-    }
-}
+//     #[test]
+//     fn test_patch() {
+//         patch_file();
+//     }
+// }

--- a/tests/chrome.rs
+++ b/tests/chrome.rs
@@ -1,6 +1,5 @@
 #[cfg(test)]
 mod tests {
-    use tokio;
     use undetected_chromedriver::chrome;
 
     #[tokio::test]

--- a/tests/headless.rs
+++ b/tests/headless.rs
@@ -2,7 +2,6 @@
 mod tests {
     use thirtyfour::prelude::ElementQueryable;
     use thirtyfour::By;
-    use tokio;
     use undetected_chromedriver::chrome;
 
     #[tokio::test]

--- a/tests/recaptcha.rs
+++ b/tests/recaptcha.rs
@@ -2,7 +2,6 @@
 mod tests {
     use thirtyfour::prelude::{ElementQueryable, ElementWaitable};
     use thirtyfour::By;
-    use tokio;
     use undetected_chromedriver::chrome;
 
     async fn get_score(driver: &thirtyfour::WebDriver) -> Option<f32> {
@@ -29,8 +28,8 @@ mod tests {
             .lines()
             .find(|line| line.contains("\"score\":"))
             .and_then(|line| {
-                let start_index = line.find(":")?;
-                let end_index = line.find(",")?;
+                let start_index = line.find(':')?;
+                let end_index = line.find(',')?;
                 line.get(start_index + 1..end_index)
             })
             .and_then(|score_str| score_str.trim().parse::<f32>().ok());


### PR DESCRIPTION
Hi,I will soon upload a video on youtube about web scraping using rust and I found your crate very useful,so thanks in advance for the work.

In spite of that,I noticed some things to fix,leaving out a big refractor to the code,which can be divided into smaller and coincidental functions,I removed some used imports and other little things to make the code idiomatic,making it adhere to [clippy](https://github.com/rust-lang/rust-clippy) standards.

Also on windows,it was not detecting the driver for me,so I added a condition to make that happen

Also I noticed a bug that was causing the cdc_ string to be deleted(or rather overwritten),which seeing the source code is not what we want,as we want to replace the 22 characters after it.
I have fixed the code so as to solve this problem,as the photos prove.
Note: the bug occasionally caused me to crash the program,as the wrong part of the binary was replaced. Now this problem is no longer there.

This is the normal chromedriver.

![chromedrvier](https://github.com/Ulyssedev/Rust-undetected-chromedriver/assets/124720521/80a72bfa-9a00-4c6f-b621-d55620c93d90)

This is after your code.

![This is after your code](https://github.com/Ulyssedev/Rust-undetected-chromedriver/assets/124720521/bb17beee-3190-4e7a-91ac-621dcb90959a)

This is after the fix :)

![This is after the fix :)](https://github.com/Ulyssedev/Rust-undetected-chromedriver/assets/124720521/3acc27b9-1fab-47c3-828c-a97204ee08f8)
