### PR TITLE
Added the option to change WebDriver capabilities

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "undetected-chromedriver"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 description = "An undetected implementation of thirtyfour."
 repository = "https://github.com/Ulyssedev/Rust-undetected-chromedriver"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,14 +2,21 @@ use rand::Rng;
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 use std::os::unix::fs::PermissionsExt;
 use std::process::Command;
-use thirtyfour::{DesiredCapabilities, WebDriver};
+use thirtyfour::{ChromeCapabilities, DesiredCapabilities, WebDriver};
 use std::error::Error;
 use std::time::Duration;
 use thirtyfour::{prelude::ElementWaitable, By};
 
 /// Fetches a new ChromeDriver executable and patches it to prevent detection.
-/// Returns a WebDriver instance.
+/// Returns a WebDriver instance, constructed with default capabilities.
 pub async fn chrome() -> Result<WebDriver, Box<dyn std::error::Error>> {
+    let caps = DesiredCapabilities::chrome();
+    chrome_caps(caps).await
+}
+
+/// Fetches a new ChromeDriver executable and patches it to prevent detection.
+/// Returns a WebDriver instance.
+pub async fn chrome_caps(mut caps: ChromeCapabilities) -> Result<WebDriver, Box<dyn std::error::Error>> {
     let os = std::env::consts::OS;
     if std::path::Path::new("chromedriver").exists()
         || std::path::Path::new("chromedriver.exe").exists()
@@ -104,7 +111,6 @@ pub async fn chrome() -> Result<WebDriver, Box<dyn std::error::Error>> {
         .arg(format!("--port={}", port))
         .spawn()
         .expect("Failed to start chromedriver!");
-    let mut caps = DesiredCapabilities::chrome();
     caps.set_no_sandbox().unwrap();
     caps.set_disable_dev_shm_usage().unwrap();
     caps.add_chrome_arg("--disable-blink-features=AutomationControlled")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,7 +122,7 @@ pub async fn chrome_caps(mut caps: ChromeCapabilities) -> Result<WebDriver, Box<
         .unwrap();
     let mut driver = None;
     let mut attempt = 0;
-    while driver.is_none() && attempt < 1 {
+    while driver.is_none() && attempt < 20 {
         attempt += 1;
         match WebDriver::new(&format!("http://localhost:{}", port), caps.clone()).await {
             Ok(d) => driver = Some(d),


### PR DESCRIPTION
I had to change the default capabilities for the WebDriver but the crate does not provide this function.

Renamed the ```chrome()``` function to ```chrome_caps``` and made it accept ```ChromeCapabilities``` as an argument.

Also created a ```chrome()``` function that calls ```chrome_caps``` with default ```ChromeCapabilities```.

Usage example (changing the downloads directory):
```rust
let mut caps = DesiredCapabilities::chrome();
let mut prefs = HashMap::new();
prefs.insert("download.default_directory", "/path/to/directory");
caps.add_chrome_option("prefs", prefs)?;
let driver = chrome_caps(caps).await?;
```